### PR TITLE
Adding feature to add parameters to repositories

### DIFF
--- a/gameta/__init__.py
+++ b/gameta/__init__.py
@@ -32,6 +32,7 @@ class GametaContext(object):
         repositories (Dict[str, Dict]): Data of all the repositories contained in the metarepo
         tags (Dict[str, List[str]]): Repository data organised according to tags
     """
+    reserved_params = ['url', 'path', 'tags']
 
     def __init__(self):
         self.is_metarepo: bool = False

--- a/gameta/__init__.py
+++ b/gameta/__init__.py
@@ -35,6 +35,7 @@ class GametaContext(object):
 
     def __init__(self):
         self.is_metarepo: bool = False
+        self.gitignore_data: List[str] = []
         self.project_dir: Optional[str] = None
         self.gameta_data: Dict = {}
         self.repositories: Dict[str, Dict] = {}
@@ -61,6 +62,44 @@ class GametaContext(object):
         """
         return join(self.project_dir, '.meta')
 
+    @property
+    def gitignore(self) -> str:
+        """
+        Returns the path to the .gitignore file of the project, i.e. where it should be if the Project has not been
+        initialised
+
+        Returns:
+            str: Path to the project's .gitignore file
+        """
+        return join(self.project_dir, '.gitignore')
+
+    def add_gitignore(self, path: str) -> None:
+        """
+        Adds the path to the gitignore_data
+
+        Args:
+            path (str): Path to be added
+
+        Returns:
+            None
+        """
+        self.gitignore_data.append(path + '/\n')
+
+    def remove_gitignore(self, path: str) -> None:
+        """
+        Removes the path from the gitignore_data
+
+        Args:
+            path (str): Path to be removed
+
+        Returns:
+            None
+        """
+        try:
+            self.gitignore_data.remove(path + '/\n')
+        except ValueError:
+            return
+
     def load(self) -> None:
         """
         Finds all repositories to manage and groups them into relative groups
@@ -80,9 +119,17 @@ class GametaContext(object):
 
         self.generate_tags()
 
+        try:
+            with open(self.gitignore, 'r') as f:
+                self.gitignore_data = f.readlines()
+        except FileNotFoundError:
+            return
+        except Exception as e:
+            raise click.ClickException(f"Could not load .meta file: {e.__class__.__name__}.{str(e)}")
+
     def export(self) -> None:
         """
-        Exports updated Gameta data to .meta file
+        Exports updated Gameta data to .meta file and gitignore data to the .gitignore file
 
         Returns:
             None
@@ -93,7 +140,15 @@ class GametaContext(object):
                 json.dump(self.gameta_data, f)
         except Exception as e:
             raise click.ClickException(
-                f"Could not export gameta data to pyproject.toml: {e.__class__.__name__}.{str(e)}"
+                f"Could not export gameta data to .meta file: {e.__class__.__name__}.{str(e)}"
+            )
+
+        try:
+            with open(self.gitignore, 'w+') as f:
+                f.writelines(self.gitignore_data)
+        except Exception as e:
+            raise click.ClickException(
+                f"Could not export gitignore data to .gitignore file: {e.__class__.__name__}.{str(e)}"
             )
 
     def generate_tags(self) -> None:

--- a/gameta/init.py
+++ b/gameta/init.py
@@ -1,6 +1,5 @@
-import json
-from os.path import splitext, basename, normpath, abspath
-from typing import Dict, Optional
+from os.path import splitext, basename, abspath
+from typing import Optional
 
 import click
 

--- a/gameta/parameters.py
+++ b/gameta/parameters.py
@@ -1,0 +1,131 @@
+import builtins
+import json
+from typing import Type, Optional, TypeVar
+
+import click
+
+from . import gameta_cli, gameta_context, GametaContext
+
+
+__all__ = ['parameters_cli']
+
+
+T = TypeVar('T', int, float, str, bool, dict, list)
+
+
+@gameta_cli.group('parameters')
+@gameta_context
+def parameters_cli(context: GametaContext) -> None:
+    """
+    CLI for managing parameters in metarepos
+    \f
+    Args:
+        context (GametaContext): Gameta Context
+
+    Returns:
+        None
+    """
+    if not context.is_metarepo:
+        raise click.ClickException(f"{context.project_dir} is not a metarepo, initialise it with 'gameta init'")
+
+
+@parameters_cli.command()
+@click.option('--parameter', '-p', type=str, required=True, help="Parameter name to be added to all child repositories")
+@click.option('--type', '-t', 'ptype', type=click.Choice(['int', 'float', 'str', 'bool', 'dict', 'list']),
+              default='str', help='Parameter type to be added')
+@click.option('--value', '-v', type=str, default=None, help="Default value to be used for all child repositories")
+@click.option('--skip-prompt', '-y', 'skip_prompt', is_flag=True, default=False,
+              help="Skip user prompt and use default values for all")
+@gameta_context
+def add(context: GametaContext, parameter: str, ptype: Optional[str], value: Optional[str], skip_prompt: bool) -> None:
+    """
+    Adds/updates a parameter to all child repositories in the .meta file, users will automatically be prompted to enter
+    the parameter value corresponding to each repository. They can provide a type and value parameter to skip this step.
+    \f
+    Args:
+        context (GametaContext): Gameta Context
+        parameter (str): Parameter name to be added to all child repositories
+        ptype (Optional[str]): Parameter type to be added
+        value (Optional[str]): Default value to be used for all child repositories, value will be rendered with type
+                               chosen
+        skip_prompt (bool): Flag to indicate if user prompt to enter values for all repositories should be skipped and
+                            default value used directly
+
+    Returns:
+        None
+
+    Examples:
+        $ gameta parameters add -p test -t str -v hello_world  # Adds parameter test with value hello_world to all repos
+        $ gameta parameters add -p test -t str -v hello_world -u  # Prompts user input for parameter values
+    """
+    click.echo(f"Adding parameter {parameter}")
+    parameter_type: Type[T] = getattr(builtins, ptype, str)
+
+    def prompt_type_parser(input_value: str) -> T:
+        """
+        Parser to convert the user inputs into the appropriate type
+        
+        Args:
+            input_value (str): Input received from the command line
+
+        Returns:
+            (int, float, str, bool, list, dict): Output parsed into the correct type
+        """
+        try:
+            return json.loads(input_value)
+        except json.JSONDecodeError:
+            return parameter_type(input_value)
+
+    try:
+        for repo, details in context.repositories.items():
+            if skip_prompt:
+                pvalue: parameter_type = value
+            else:
+                pvalue: parameter_type = click.prompt(
+                    f"Please enter the parameter value for repository {repo} or >* to skip", default=value,
+                    value_proc=prompt_type_parser
+                )
+                if pvalue == ">*":
+                    click.echo(f"Skip token was entered, defaulting to default value {value}")
+                    pvalue = value
+                elif not isinstance(pvalue, parameter_type):
+                    click.echo(f"Value {pvalue} (type: {type(pvalue)}) entered is not the required type "
+                               f"{parameter_type}, defaulting to default value {value}")
+                    pvalue = value
+            details[parameter] = pvalue
+            click.echo(f"Adding {parameter} value {pvalue} for {repo}")
+        context.export()
+        click.echo(f"Successfully added parameter {parameter} to .meta file")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")
+
+
+@parameters_cli.command()
+@click.option('--parameter', '-p', type=str, required=True,
+              help="Parameter name to be deleted from all child repositories")
+@gameta_context
+def delete(context: GametaContext, parameter: str) -> None:
+    """
+    Deletes a parameter from all child repositories
+    \f
+    Args:
+        context (GametaContext): Gameta Context
+        parameter (str): Parameter name to be deleted from all child repositories
+
+    Returns:
+        None
+    """
+    if parameter in context.reserved_params:
+        raise click.ClickException(f"Parameter {parameter} is a reserved parameter {context.reserved_params}")
+
+    try:
+        click.echo(f"Deleting parameter {parameter}")
+        for repo, details in context.repositories.items():
+            try:
+                del details[parameter]
+            except KeyError:
+                continue
+        context.export()
+        click.echo(f"Successfully deleted parameter {parameter} from .meta file")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")

--- a/gameta/repos.py
+++ b/gameta/repos.py
@@ -70,25 +70,28 @@ def add(context: GametaContext, name: str, url: str, path: str, overwrite: bool)
     except GitError as e:
         raise click.ClickException(f'Error cloning {name} into directory {clone_path}: {e.__class__.__name__}.{str(e)}')
 
-    click.echo(f"Repository {name} has been added locally")
-    if name in context.repositories:
-        if overwrite is True:
-            click.echo(f"Overwriting repository {name} in .meta file")
+    try:
+        click.echo(f"Repository {name} has been added locally")
+        if name in context.repositories:
+            if overwrite is True:
+                click.echo(f"Overwriting repository {name} in .meta file")
+            else:
+                click.echo(f"Repository {name} has already been added to .meta file")
+                return
         else:
-            click.echo(f"Repository {name} has already been added to .meta file")
-            return
-    else:
-        click.echo(f"Adding {name} to .meta file")
+            click.echo(f"Adding {name} to .meta file")
 
-    context.repositories[name] = {
-        'url': url,
-        'path': path,
-    }
-    context.add_gitignore(path)
-    context.export()
+        context.repositories[name] = {
+            'url': url,
+            'path': path,
+        }
+        context.add_gitignore(path)
+        context.export()
 
-    click.echo(f"Successfully added repository {name}")
-    return context.repositories[name]
+        click.echo(f"Successfully added repository {name}")
+        return context.repositories[name]
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")
 
 
 @repo_cli.command()
@@ -111,18 +114,21 @@ def delete(context: GametaContext, name: str, clear: bool) -> None:
         $ gameta repo delete -n repo_name
         $ gameta repo delete -n repo_name -c  # Clears the local repository
     """
-    click.echo(f"Deleting repository {name} from .meta file")
-    if name not in context.repositories:
-        click.echo(f"Repository {name} does not exist in the .meta file, ignoring")
-        return
+    try:
+        click.echo(f"Deleting repository {name} from .meta file")
+        if name not in context.repositories:
+            click.echo(f"Repository {name} does not exist in the .meta file, ignoring")
+            return
 
-    if clear:
-        click.echo(f"Clearing repository {name} locally")
-        rmtree(join(context.project_dir, context.repositories[name]["path"]), ignore_errors=True)
-    context.remove_gitignore(context.repositories[name]["path"])
-    del context.repositories[name]
-    context.export()
-    click.echo(f"Repository {name} successfully deleted")
+        if clear:
+            click.echo(f"Clearing repository {name} locally")
+            rmtree(join(context.project_dir, context.repositories[name]["path"]), ignore_errors=True)
+        context.remove_gitignore(context.repositories[name]["path"])
+        del context.repositories[name]
+        context.export()
+        click.echo(f"Repository {name} successfully deleted")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")
 
 
 @repo_cli.command()
@@ -164,46 +170,49 @@ def update(
     if name not in context.repositories:
         raise click.ClickException(f"Repository {name} does not exist in the .meta file, please add it first")
 
-    click.echo(f"Updating repository {name} with new details (name: {new_name}, url: {new_url}, path: {new_path})")
-    curr_repo_details: Dict = context.repositories[name]
+    try:
+        click.echo(f"Updating repository {name} with new details (name: {new_name}, url: {new_url}, path: {new_path})")
+        curr_repo_details: Dict = context.repositories[name]
 
-    # Update the details
-    new_repo_details: Dict = deepcopy(context.repositories[name])
-    for key, value in [('url', new_url), ('path', new_path)]:
-        if value is not None:
-            new_repo_details[key] = value
+        # Update the details
+        new_repo_details: Dict = deepcopy(context.repositories[name])
+        for key, value in [('url', new_url), ('path', new_path)]:
+            if value is not None:
+                new_repo_details[key] = value
 
-    if new_name is not None:
-        del context.repositories[name]
-        name = new_name
+        if new_name is not None:
+            del context.repositories[name]
+            name = new_name
 
-    # Perform a physical sync with the updated details
-    if sync:
-        click.echo("Performing a physical sync")
-        if new_url is not None:
-            # Only URL changes, need to clear the existing path and clone repository
-            click.echo(f"Cloning repository from new URL: {new_url}")
-            rmtree(join(context.project_dir, curr_repo_details['path']), ignore_errors=True)
-            Repo.clone_from(new_url, normpath(join(context.project_dir, new_repo_details['path'])))
-        elif new_url is None and new_path is not None:
-            # Only path changes, need to move the directory to the new location
-            click.echo(f"Copying repository to new path: {new_path}")
-            copytree(
-                join(context.project_dir, curr_repo_details["path"]),
-                join(context.project_dir, new_repo_details["path"])
-            )
-            rmtree(join(context.project_dir, curr_repo_details['path']), ignore_errors=True)
-        else:
-            # No physical changes
-            click.echo("No physical changes")
-        click.echo("Sync complete")
+        # Perform a physical sync with the updated details
+        if sync:
+            click.echo("Performing a physical sync")
+            if new_url is not None:
+                # Only URL changes, need to clear the existing path and clone repository
+                click.echo(f"Cloning repository from new URL: {new_url}")
+                rmtree(join(context.project_dir, curr_repo_details['path']), ignore_errors=True)
+                Repo.clone_from(new_url, normpath(join(context.project_dir, new_repo_details['path'])))
+            elif new_url is None and new_path is not None:
+                # Only path changes, need to move the directory to the new location
+                click.echo(f"Copying repository to new path: {new_path}")
+                copytree(
+                    join(context.project_dir, curr_repo_details["path"]),
+                    join(context.project_dir, new_repo_details["path"])
+                )
+                rmtree(join(context.project_dir, curr_repo_details['path']), ignore_errors=True)
+            else:
+                # No physical changes
+                click.echo("No physical changes")
+            click.echo("Sync complete")
 
-    # Export the updated details
-    context.remove_gitignore(curr_repo_details["path"])
-    context.add_gitignore(new_repo_details["path"])
-    context.repositories[name] = new_repo_details
-    context.export()
-    click.echo(f"Successfully updated repository {name} with new details")
+        # Export the updated details
+        context.remove_gitignore(curr_repo_details["path"])
+        context.add_gitignore(new_repo_details["path"])
+        context.repositories[name] = new_repo_details
+        context.export()
+        click.echo(f"Successfully updated repository {name} with new details")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")
 
 
 @repo_cli.command()

--- a/gameta/repos.py
+++ b/gameta/repos.py
@@ -84,6 +84,7 @@ def add(context: GametaContext, name: str, url: str, path: str, overwrite: bool)
         'url': url,
         'path': path,
     }
+    context.add_gitignore(path)
     context.export()
 
     click.echo(f"Successfully added repository {name}")
@@ -118,6 +119,7 @@ def delete(context: GametaContext, name: str, clear: bool) -> None:
     if clear:
         click.echo(f"Clearing repository {name} locally")
         rmtree(join(context.project_dir, context.repositories[name]["path"]), ignore_errors=True)
+    context.remove_gitignore(context.repositories[name]["path"])
     del context.repositories[name]
     context.export()
     click.echo(f"Repository {name} successfully deleted")
@@ -197,6 +199,8 @@ def update(
         click.echo("Sync complete")
 
     # Export the updated details
+    context.remove_gitignore(curr_repo_details["path"])
+    context.add_gitignore(new_repo_details["path"])
     context.repositories[name] = new_repo_details
     context.export()
     click.echo(f"Successfully updated repository {name} with new details")

--- a/gameta/tags.py
+++ b/gameta/tags.py
@@ -47,10 +47,13 @@ def add(context: GametaContext, name: str, tags: List[str]) -> None:
     if name not in context.repositories:
         raise click.ClickException(f"Repository {name} does not exist in .meta file")
 
-    repo_details: Dict = context.repositories[name]
-    repo_details['tags'] = sorted(list(set(repo_details.get('tags', [])) | set(tags)))
-    context.export()
-    click.echo(f"Successfully added tags to repository {name}")
+    try:
+        repo_details: Dict = context.repositories[name]
+        repo_details['tags'] = sorted(list(set(repo_details.get('tags', [])) | set(tags)))
+        context.export()
+        click.echo(f"Successfully added tags to repository {name}")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")
 
 
 @tags_cli.command()
@@ -76,7 +79,10 @@ def delete(context: GametaContext, name: str, tags: List[str]) -> None:
     if name not in context.repositories:
         raise click.ClickException(f"Repository {name} does not exist in .meta file")
 
-    repo_details: Dict = context.repositories[name]
-    repo_details['tags'] = sorted(list(set(repo_details.get('tags', [])) - set(tags)))
-    context.export()
-    click.echo(f"Successfully deleted tags from repository {name}")
+    try:
+        repo_details: Dict = context.repositories[name]
+        repo_details['tags'] = sorted(list(set(repo_details.get('tags', [])) - set(tags)))
+        context.export()
+        click.echo(f"Successfully deleted tags from repository {name}")
+    except Exception as e:
+        raise click.ClickException(f"{e.__class__.__name__}.{str(e)}")

--- a/tests/data/.gitignore
+++ b/tests/data/.gitignore
@@ -1,0 +1,132 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# PyCharm
+.idea

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,11 +1,9 @@
 import zipfile
-from os import getenv
 from os.path import join, dirname
 from shutil import copyfile, copytree
 from unittest import TestCase
 from unittest.mock import patch
 
-from click import Context
 from click.testing import CliRunner
 from gameta import GametaContext
 
@@ -17,8 +15,31 @@ class TestApply(TestCase):
         self.runner = CliRunner()
         self.apply = apply
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_all_repositories(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_key_parameters_not_provided(self, mock_ensure_object):
+        with self.runner.isolated_filesystem() as f:
+            with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
+                template.extractall(f)
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: apply [OPTIONS]\n"
+                "Try 'apply --help' for help.\n"
+                "\n"
+                "Error: Missing option '--command' / '-c'.\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_all_repositories(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune'
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -26,29 +47,26 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': [],
-                'repositories': [],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command']])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['gameta', 'GitPython', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['gameta', 'GitPython', 'gitdb']\n"
                 "Executing git fetch --all --tags --prune in gameta\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_tagged_repositories(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_tagged_repositories(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+            'tags': ('c', )
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -56,28 +74,25 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': ['c'],
-                'repositories': [],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command'], '-t', params['tags'][0]])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['GitPython', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['GitPython', 'gitdb']\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_tagged_repositories_that_do_not_exist(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_tagged_repositories_that_do_not_exist(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+            'tags': ('hello', 'world')
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -85,29 +100,28 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': ['hello', 'world'],
-                'repositories': [],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.apply, ['--command', params['command'], '-t', params['tags'][0], '-t', params['tags'][1]]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['gameta', 'GitPython', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['gameta', 'GitPython', 'gitdb']\n"
                 "Executing git fetch --all --tags --prune in gameta\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_specified_repositories(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_specified_repositories(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+            'repositories': ('GitPython', )
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -115,27 +129,24 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': [],
-                'repositories': ['GitPython'],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command'], '-r', params['repositories'][0]])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['GitPython']\n"
+                f"Applying '{params['command']}' to repos ['GitPython']\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_specified_repositories_that_do_not_exist(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_specified_repositories_that_do_not_exist(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+            'repositories': ('hello', 'world')
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -143,29 +154,30 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': [],
-                'repositories': ['hello', 'world'],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.apply,
+                ['--command', params['command'], '-r', params['repositories'][0], '-r', params['repositories'][1]]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['gameta', 'GitPython', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['gameta', 'GitPython', 'gitdb']\n"
                 "Executing git fetch --all --tags --prune in gameta\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_to_merged_tags_and_repos(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_to_merged_tags_and_repos(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+            'tags': ('metarepo', ),
+            'repositories': ('gitdb', )
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -173,28 +185,26 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': ['metarepo'],
-                'repositories': ['gitdb'],
-                'shell': False,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.apply, ['--command', params['command'], '-t', params['tags'][0], '-r', params['repositories'][0]]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['gameta', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['gameta', 'gitdb']\n"
                 "Executing git fetch --all --tags --prune in gameta\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_command_in_separate_shell(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_command_in_separate_shell(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune',
+        }
         with self.runner.isolated_filesystem() as f:
             copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
@@ -202,29 +212,25 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': [],
-                'repositories': [],
-                'shell': True,
-                'raise_errors': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command'], '-s'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                "Applying 'git fetch --all --tags --prune' to repos ['gameta', 'GitPython', 'gitdb']\n"
+                f"Applying '{params['command']}' to repos ['gameta', 'GitPython', 'gitdb'] in a separate shell\n"
                 "Executing git fetch --all --tags --prune in gameta\n"
                 "Executing git fetch --all --tags --prune in GitPython\n"
                 "Executing git fetch --all --tags --prune in gitdb\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_apply_raise_errors(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_raise_errors(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -233,16 +239,41 @@ class TestApply(TestCase):
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
                 template.extractall(join(f, 'core'))
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.apply, obj=GametaContext())
-            context.params = {
-                'command': 'git fetch --all --tags --prune',
-                'tags': [],
-                'repositories': [],
-                'shell': False,
-                'raise_errors': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.apply)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command'], '-e'])
             self.assertEqual(result.exit_code, 1)
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_apply_verbose(self, mock_ensure_object):
+        params = {
+            'command': 'git fetch --all --tags --prune'
+        }
+        with self.runner.isolated_filesystem() as f:
+            copytree(join(dirname(dirname(__file__)), '.git'), join(f, '.git'))
+            with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
+                template.extractall(f)
+            with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitdb.zip'), 'r') as template:
+                template.extractall(join(f, 'core'))
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.apply, ['--command', params['command'], '-v'])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Applying '{params['command']}' to repos ['gameta', 'GitPython', 'gitdb']\n"
+                "Executing git fetch --all --tags --prune in gameta\n"
+                "Fetching origin\n"
+                "\n"
+                "Executing git fetch --all --tags --prune in GitPython\n"
+                "Fetching origin\n"
+                "\n"
+                "Executing git fetch --all --tags --prune in gitdb\n"
+                "Fetching origin\n"
+                "\n"
+            )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,7 +7,6 @@ from shutil import copyfile
 from unittest import TestCase
 from unittest.mock import patch
 
-from click import Context
 from click.testing import CliRunner
 
 from gameta import GametaContext
@@ -19,13 +18,12 @@ class TestInit(TestCase):
         self.runner = CliRunner()
         self.init = init
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_init_with_default_values_folder_is_not_a_git_repo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_init_with_default_values_folder_is_not_a_git_repo(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
-            context = Context(self.init, obj=GametaContext())
-            context.params = {'overwrite': False, 'git': False}
-            context.obj.project_dir = f
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.init)
             self.assertEqual(result.exit_code, 1)
             self.assertEqual(
@@ -34,14 +32,13 @@ class TestInit(TestCase):
                 f"Error: {f} is not a valid git repo, initialise it with -g flag\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_init_with_git_is_true_folder_is_not_a_git_repo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_init_with_git_is_true_folder_is_not_a_git_repo(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
-            context = Context(self.init, obj=GametaContext())
-            context.params = {'overwrite': False, 'git': True}
-            context.obj.project_dir = f
-            mock_context.return_value = context
-            result = self.runner.invoke(self.init)
+            context = GametaContext()
+            context.project_dir = f
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.init, ['--git'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
@@ -63,15 +60,14 @@ class TestInit(TestCase):
                     }
                 )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_init_with_default_values_folder_is_a_git_repo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_init_with_default_values_folder_is_a_git_repo(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
-            context = Context(self.init, obj=GametaContext())
-            context.params = {'overwrite': False, 'git': False}
-            context.obj.project_dir = f
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.init)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
@@ -93,17 +89,16 @@ class TestInit(TestCase):
                     }
                 )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_init_with_default_values_folder_is_a_metarepo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_init_with_default_values_folder_is_a_metarepo(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.init, obj=GametaContext())
-            context.params = {'overwrite': False, 'git': False}
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.init)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
@@ -125,18 +120,17 @@ class TestInit(TestCase):
                     }
                 )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_init_with_overwrite_folder_is_a_metarepo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_init_with_overwrite_folder_is_a_metarepo(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.init, obj=GametaContext())
-            context.params = {'overwrite': True, 'git': False}
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.init)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.init, ['--overwrite'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
@@ -163,8 +157,8 @@ class TestSync(TestCase):
         self.runner = CliRunner()
         self.sync = sync
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_sync_empty_meta_file(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_sync_empty_meta_file(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -174,10 +168,10 @@ class TestSync(TestCase):
                         'projects': {}
                     }, m
                 )
-            context = Context(self.sync, obj=GametaContext())
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.sync)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
@@ -185,16 +179,16 @@ class TestSync(TestCase):
                 f'Syncing all child repositories in metarepo {f}\n'
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_sync_all_repos(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_sync_all_repos(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.sync, obj=GametaContext())
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.sync)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,6 @@
+from unittest import TestCase
+
+
+class TestParameter(TestCase):
+
+    pass

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,6 +1,604 @@
+import json
+from os.path import join, dirname
+from shutil import copyfile
 from unittest import TestCase
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from gameta import GametaContext
+from gameta.parameters import add, delete
 
 
-class TestParameter(TestCase):
+class TestAdd(TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+        self.add = add
 
-    pass
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_missing_key_parameters(self, mock_ensure_object):
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.add)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: add [OPTIONS]\n"
+                "Try 'add --help' for help.\n"
+                "\n"
+                "Error: Missing option '--parameter' / '-p'.\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_skip_user_prompt_default_values(self, mock_ensure_object):
+        params = {
+            'parameter': 'test'
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.add, ['-p', params['parameter'], '-y'])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Adding {params['parameter']} value None for gameta\n"
+                f"Adding {params['parameter']} value None for GitPython\n"
+                f"Adding {params['parameter']} value None for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: None,
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: None,
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: None,
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_skip_user_prompt_user_provided_default_value(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'value': 'hello_world'
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.add, ['-p', params['parameter'], '-y', '-v', params['value']])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Adding {params['parameter']} value {params['value']} for gameta\n"
+                f"Adding {params['parameter']} value {params['value']} for GitPython\n"
+                f"Adding {params['parameter']} value {params['value']} for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: params['value'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: params['value'],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: params['value'],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_skip_user_prompt_default_type_not_in_choice(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'type': 'test'
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.add, ['-p', params['parameter'], '-y', '-t', params['type']])
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: add [OPTIONS]\n"
+                "Try 'add --help' for help.\n"
+                "\n"
+                "Error: Invalid value for '--type' / '-t': invalid choice: test. "
+                "(choose from int, float, str, bool, dict, list)\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_user_prompt_all_value_prompted(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'value': 'hello_world',
+            'user_prompt': ['gameta', 'GitPython', 'gitdb']
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['-p', params['parameter'], '-v', params['value']], input='\n'.join(params['user_prompt'])
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Please enter the parameter value for repository gameta or >* to skip [hello_world]: "
+                f"{params['user_prompt'][0]}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][0]} for gameta\n"
+                f"Please enter the parameter value for repository GitPython or >* to skip [hello_world]: "
+                f"{params['user_prompt'][1]}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][1]} for GitPython\n"
+                f"Please enter the parameter value for repository gitdb or >* to skip [hello_world]: "
+                f"{params['user_prompt'][2]}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][2]} for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: params['user_prompt'][1],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: params['user_prompt'][0],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: params['user_prompt'][2],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_user_prompt_skipping_with_user_provided_default_value(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'value': 'hello_world',
+            'user_prompt': ['gameta', '>*', 'gitdb']
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['-p', params['parameter'], '-v', params['value']], input='\n'.join(params['user_prompt'])
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Please enter the parameter value for repository gameta or >* to skip [hello_world]: "
+                f"{params['user_prompt'][0]}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][0]} for gameta\n"
+                f"Please enter the parameter value for repository GitPython or >* to skip [hello_world]: "
+                f"{params['user_prompt'][1]}\n"
+                f"Skip token was entered, defaulting to default value {params['value']}\n"
+                f"Adding {params['parameter']} value {params['value']} for GitPython\n"
+                f"Please enter the parameter value for repository gitdb or >* to skip [hello_world]: "
+                f"{params['user_prompt'][2]}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][2]} for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: params['value'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: params['user_prompt'][0],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: params['user_prompt'][2],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_user_prompt_complex_user_input(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'value': 'hello_world',
+            'type': 'dict',
+            'user_prompt': [{'a': [1, 2, 3]}, {'a': [4, 5, 6]}, {'a': [1, 6, 7], 'c': [4, 2, 8]}]
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['-p', params['parameter'], '-v', params['value'], '--type', params['type']],
+                input='\n'.join([json.dumps(p) for p in params['user_prompt']])
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Please enter the parameter value for repository gameta or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][0])}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][0]} for gameta\n"
+                f"Please enter the parameter value for repository GitPython or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][1])}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][1]} for GitPython\n"
+                f"Please enter the parameter value for repository gitdb or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][2])}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][2]} for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: params['user_prompt'][1],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: params['user_prompt'][0],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: params['user_prompt'][2],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_user_prompt_user_input_does_not_match_required_type(self, mock_ensure_object):
+        params = {
+            'parameter': 'test',
+            'value': 'hello_world',
+            'type': 'dict',
+            'user_prompt': [{'a': [1, 2, 3]}, ['a', [4, 5, 6]], {'a': [1, 6, 7], 'c': [4, 2, 8]}]
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['-p', params['parameter'], '-v', params['value'], '--type', params['type']],
+                input='\n'.join([json.dumps(p) for p in params['user_prompt']])
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Adding parameter {params['parameter']}\n"
+                f"Please enter the parameter value for repository gameta or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][0])}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][0]} for gameta\n"
+                f"Please enter the parameter value for repository GitPython or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][1])}\n"
+                f"Value {params['user_prompt'][1]} (type: {type(params['user_prompt'][1])}) entered is not the "
+                f"required type {dict}, defaulting to default value {params['value']}\n"
+                f"Adding {params['parameter']} value {params['value']} for GitPython\n"
+                f"Please enter the parameter value for repository gitdb or >* to skip [hello_world]: "
+                f"{json.dumps(params['user_prompt'][2])}\n"
+                f"Adding {params['parameter']} value {params['user_prompt'][2]} for gitdb\n"
+                f"Successfully added parameter {params['parameter']} to .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                params['parameter']: params['value'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                params['parameter']: params['user_prompt'][0],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                params['parameter']: params['user_prompt'][2],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+
+class TestDelete(TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+        self.delete = delete
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_parameters_missing_key_parameters(self, mock_ensure_object):
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: delete [OPTIONS]\n"
+                "Try 'delete --help' for help.\n"
+                "\n"
+                "Error: Missing option '--parameter' / '-p'.\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_parameters_parameter_does_not_exist(self, mock_ensure_object):
+        params = {
+            'parameter': 'test'
+        }
+        with self.runner.isolated_filesystem() as f:
+            copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['-p', params['parameter']])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Deleting parameter {params['parameter']}\n"
+                f"Successfully deleted parameter {params['parameter']} from .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_parameters_all_parameters_deleted(self, mock_ensure_object):
+        params = {
+            'parameter': 'test'
+        }
+        with self.runner.isolated_filesystem() as f:
+            with open(join(dirname(__file__), 'data', '.meta_other_repos'), 'r') as m1:
+                output = json.load(m1)
+                with open(join(f, '.meta'), 'w+') as m2:
+                    output['projects']['gameta'].update({"test": {'a': [1, 2, 3]}})
+                    output['projects']['GitPython'].update({'test': {'a': [4, 5, 6]}})
+                    output['projects']['gitdb'].update({'test': {'a': [1, 6, 7], 'c': [4, 2, 8]}})
+                    json.dump(output, m2)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['-p', params['parameter']])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Deleting parameter {params['parameter']}\n"
+                f"Successfully deleted parameter {params['parameter']} from .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_parameters_partial_parameter_deleted(self, mock_ensure_object):
+        params = {
+            'parameter': 'test'
+        }
+        with self.runner.isolated_filesystem() as f:
+            with open(join(dirname(__file__), 'data', '.meta_other_repos'), 'r') as m1:
+                output = json.load(m1)
+                with open(join(f, '.meta'), 'w+') as m2:
+                    output['projects']['gameta'].update({"test": {'a': [1, 2, 3]}})
+                    output['projects']['gitdb'].update({'test': {'a': [1, 6, 7], 'c': [4, 2, 8]}})
+                    json.dump(output, m2)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['-p', params['parameter']])
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(
+                result.output,
+                f"Deleting parameter {params['parameter']}\n"
+                f"Successfully deleted parameter {params['parameter']} from .meta file\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git'
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                'url': 'git@github.com:genius-systems/gameta.git'
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git'
+                            }
+                        }
+                    }
+                )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_parameters_attempting_to_delete_reserved_parameters(self, mock_ensure_object):
+        params = {
+            'parameter': 'url'
+        }
+        with self.runner.isolated_filesystem() as f:
+            with open(join(dirname(__file__), 'data', '.meta_other_repos'), 'r') as m1:
+                output = json.load(m1)
+                with open(join(f, '.meta'), 'w+') as m2:
+                    output['projects']['gameta'].update({"test": {'a': [1, 2, 3]}})
+                    output['projects']['GitPython'].update({'test': {'a': [4, 5, 6]}})
+                    output['projects']['gitdb'].update({'test': {'a': [1, 6, 7], 'c': [4, 2, 8]}})
+                    json.dump(output, m2)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['-p', params['parameter']])
+            self.assertEqual(result.exit_code, 1)
+            self.assertEqual(
+                result.output,
+                f"Error: Parameter {params['parameter']} is a reserved parameter ['url', 'path', 'tags']\n"
+            )
+            with open(join(f, '.meta'), 'r') as m:
+                self.assertEqual(
+                    json.load(m),
+                    {
+                        'projects': {
+                            'GitPython': {
+                                'path': 'GitPython',
+                                'tags': ['a', 'b', 'c'],
+                                'url': 'https://github.com/gitpython-developers/GitPython.git',
+                                'test': {'a': [4, 5, 6]}
+                            },
+                            'gameta': {
+                                'path': '.',
+                                'tags': ['metarepo'],
+                                'url': 'git@github.com:genius-systems/gameta.git',
+                                'test': {'a': [1, 2, 3]}
+                            },
+                            'gitdb': {
+                                'path': 'core/gitdb',
+                                'tags': ['a', 'c', 'd'],
+                                'url': 'https://github.com/gitpython-developers/gitdb.git',
+                                'test': {'a': [1, 6, 7], 'c': [4, 2, 8]}
+                            }
+                        }
+                    }
+                )

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -18,31 +18,52 @@ class TestAdd(TestCase):
         self.runner = CliRunner()
         self.add = add
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_added_to_meta_file_and_create_gitignore_and_clone(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_key_parameters_not_provided(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/GitPython.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.add)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: add [OPTIONS]\n"
+                "Try 'add --help' for help.\n"
+                "\n"
+                "Error: Missing option '--name' / '-n'.\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_added_to_meta_file_and_create_gitignore_and_clone(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/GitPython.git',
+            'path': 'GitPython'
+        }
+        with self.runner.isolated_filesystem() as f:
+            with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
+                template.extractall(f)
+            copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Adding {context.params["name"]} to .meta file\n'
-                f'Successfully added repository {context.params["name"]}\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Adding {params["name"]} to .meta file\n'
+                f'Successfully added repository {params["name"]}\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -67,32 +88,33 @@ class TestAdd(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_added_to_meta_file_and_add_path_to_gitignore_and_clone(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_added_to_meta_file_and_add_path_to_gitignore_and_clone(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/GitPython.git',
+            'path': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
             copyfile(join(dirname(__file__), 'data', '.gitignore'), join(f, '.gitignore'))
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/GitPython.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Adding {context.params["name"]} to .meta file\n'
-                f'Successfully added repository {context.params["name"]}\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Adding {params["name"]} to .meta file\n'
+                f'Successfully added repository {params["name"]}\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -117,34 +139,35 @@ class TestAdd(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertTrue('GitPython/\n' in set(g.readlines()))
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_invalid_repository(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_invalid_repository(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://test.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://test.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 1)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Error: Error cloning {context.params["name"]} into directory {join(f, context.params["path"])}: '
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Error: Error cloning {params["name"]} into directory {join(f, params["path"])}: '
                 f"GitCommandError.Cmd('git') failed due to: exit code(128)\n"
-                f"  cmdline: git clone -v {context.params['url']} {join(f, context.params['path'])}\n"
-                f"  stderr: 'Cloning into '{join(f, context.params['path'])}'...\n" +
+                f"  cmdline: git clone -v {params['url']} {join(f, params['path'])}\n"
+                f"  stderr: 'Cloning into '{join(f, params['path'])}'...\n" +
                 "fatal: unable to access '{url}': Could not resolve host: {host}\n'\n".format(
-                    url=context.params["url"] + '/', host=context.params["url"].split('https://')[1]
+                    url=params["url"] + '/', host=params["url"].split('https://')[1]
                 )
             )
             self.assertFalse(exists(join(f, 'GitPython')))
@@ -162,8 +185,13 @@ class TestAdd(TestCase):
                     }
                 )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_already_exists_in_meta_file(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_already_exists_in_meta_file(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/GitPython.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -176,24 +204,20 @@ class TestAdd(TestCase):
                         "tags": ['a', 'b', 'c']
                     }
                     json.dump(output, m2)
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/GitPython.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Repository {context.params["name"]} has already been added to .meta file\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Repository {params["name"]} has already been added to .meta file\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -215,12 +239,14 @@ class TestAdd(TestCase):
                         }
                     }
                 )
-            self.assertTrue(exists(join(f, '.gitignore')))
-            with open(join(f, '.gitignore'), 'r') as g:
-                self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_already_exists_in_meta_file_overwritten(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_already_exists_in_meta_file_overwritten(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/gitdb.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -232,25 +258,21 @@ class TestAdd(TestCase):
                         'path': 'GitPython',
                     }
                     json.dump(output, m2)
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/gitdb.git',
-                'path': 'GitPython',
-                'overwrite': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path'], '-o']
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Overwriting repository {context.params["name"]} in .meta file\n'
-                f'Successfully added repository {context.params["name"]}\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Overwriting repository {params["name"]} in .meta file\n'
+                f'Successfully added repository {params["name"]}\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['gitdb', 'doc', 'setup.py']))
@@ -275,34 +297,35 @@ class TestAdd(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_already_exists_locally(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_already_exists_locally(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/GitPython.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/GitPython.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} exists locally, skipping clone\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Adding {context.params["name"]} to .meta file\n'
-                f'Successfully added repository {context.params["name"]}\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} exists locally, skipping clone\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Adding {params["name"]} to .meta file\n'
+                f'Successfully added repository {params["name"]}\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -327,8 +350,13 @@ class TestAdd(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_already_exists_locally_and_in_meta_file(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_already_exists_locally_and_in_meta_file(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://github.com/gitpython-developers/GitPython.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -342,25 +370,21 @@ class TestAdd(TestCase):
                         'path': 'GitPython',
                     }
                     json.dump(output, m2)
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://github.com/gitpython-developers/GitPython.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Repository {context.params["name"]} exists locally, skipping clone\n'
-                f'Repository {context.params["name"]} has been added locally\n'
-                f'Repository {context.params["name"]} has already been added to .meta file\n'
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Repository {params["name"]} exists locally, skipping clone\n'
+                f'Repository {params["name"]} has been added locally\n'
+                f'Repository {params["name"]} has already been added to .meta file\n'
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -381,37 +405,35 @@ class TestAdd(TestCase):
                         }
                     }
                 )
-            self.assertTrue(exists(join(f, '.gitignore')))
-            with open(join(f, '.gitignore'), 'r') as g:
-                self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_add_repository_already_exists_locally_parameters_differ(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_add_repository_already_exists_locally_parameters_differ(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'url': 'https://test.git',
+            'path': 'GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.add, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'url': 'https://test.git',
-                'path': 'GitPython',
-                'overwrite': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.add)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.add, ['--name', params['name'], '--url', params['url'], '--path', params['path']]
+            )
             self.assertEqual(result.exit_code, 1)
             self.assertEqual(
                 result.output,
-                f'Adding git repository {context.params["name"]}, {context.params["url"]} to '
-                f'{join(f, context.params["path"])}\n'
-                f'Error: URL of repository at {join(f, context.params["name"])} '
+                f'Adding git repository {params["name"]}, {params["url"]} to '
+                f'{join(f, params["path"])}\n'
+                f'Error: URL of repository at {join(f, params["name"])} '
                 f'(https://github.com/gitpython-developers/GitPython.git) '
-                f'does not match the requested url {context.params["url"]}\n'
+                f'does not match the requested url {params["url"]}\n'
             )
             with open(join(f, '.meta'), 'r') as m:
                 self.assertEqual(
@@ -426,9 +448,6 @@ class TestAdd(TestCase):
                         }
                     }
                 )
-            self.assertTrue(exists(join(f, '.gitignore')))
-            with open(join(f, '.gitignore'), 'r') as g:
-                self.assertCountEqual(g.readlines(), ['GitPython/\n'])
 
 
 class TestDelete(TestCase):
@@ -436,8 +455,31 @@ class TestDelete(TestCase):
         self.runner = CliRunner()
         self.delete = delete
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_delete_repository_deleted_and_cleared_gitignore_does_not_exist(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_key_parameters_not_provided(self, mock_ensure_object):
+        with self.runner.isolated_filesystem() as f:
+            with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
+                template.extractall(f)
+            copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: delete [OPTIONS]\n"
+                "Try 'delete --help' for help.\n"
+                "\n"
+                "Error: Missing option '--name' / '-n'.\n"
+            )
+
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_repository_deleted_and_cleared_gitignore_does_not_exist(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -452,21 +494,17 @@ class TestDelete(TestCase):
                         'tags': ['a', 'b', 'c']
                     }
                     json.dump(output, m2)
-            context = Context(self.delete, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'clear': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.delete)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['--name', params['name'], '-c'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f"Deleting repository {context.params['name']} from .meta file\n"
-                f"Clearing repository {context.params['name']} locally\n"
-                f"Repository {context.params['name']} successfully deleted\n"
+                f"Deleting repository {params['name']} from .meta file\n"
+                f"Clearing repository {params['name']} locally\n"
+                f"Repository {params['name']} successfully deleted\n"
             )
             self.assertFalse(exists(join(f, 'GitPython')))
             with open(join(f, '.meta'), 'r') as m:
@@ -486,8 +524,11 @@ class TestDelete(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertCountEqual(g.readlines(), [])
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_delete_repository_deleted_and_cleared_gitignore_exist_but_does_not_contain_path(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_repository_deleted_and_cleared_gitignore_exist_but_does_not_contain_path(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -503,21 +544,17 @@ class TestDelete(TestCase):
                     }
                     json.dump(output, m2)
             copyfile(join(dirname(__file__), 'data', '.gitignore'), join(f, '.gitignore'))
-            context = Context(self.delete, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'clear': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.delete)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['--name', params['name'], '-c'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f"Deleting repository {context.params['name']} from .meta file\n"
-                f"Clearing repository {context.params['name']} locally\n"
-                f"Repository {context.params['name']} successfully deleted\n"
+                f"Deleting repository {params['name']} from .meta file\n"
+                f"Clearing repository {params['name']} locally\n"
+                f"Repository {params['name']} successfully deleted\n"
             )
             self.assertFalse(exists(join(f, 'GitPython')))
             with open(join(f, '.meta'), 'r') as m:
@@ -537,8 +574,11 @@ class TestDelete(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertFalse("GitPython/\n" in g.readlines())
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_delete_repository_deleted_and_cleared_gitignore_exist_and_contains_path(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_repository_deleted_and_cleared_gitignore_exist_and_contains_path(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -558,21 +598,17 @@ class TestDelete(TestCase):
                 with open(join(f, '.gitignore'), 'w+') as g2:
                     output.append('GitPython/\n')
                     g2.writelines(output)
-            context = Context(self.delete, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'clear': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.delete)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['--name', params['name'], '-c'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f"Deleting repository {context.params['name']} from .meta file\n"
-                f"Clearing repository {context.params['name']} locally\n"
-                f"Repository {context.params['name']} successfully deleted\n"
+                f"Deleting repository {params['name']} from .meta file\n"
+                f"Clearing repository {params['name']} locally\n"
+                f"Repository {params['name']} successfully deleted\n"
             )
             self.assertFalse(exists(join(f, 'GitPython')))
             with open(join(f, '.meta'), 'r') as m:
@@ -592,8 +628,11 @@ class TestDelete(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertFalse("GitPython/\n" in g.readlines())
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_delete_repository_deleted_but_not_cleared(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_repository_deleted_but_not_cleared(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -608,20 +647,16 @@ class TestDelete(TestCase):
                         'tags': ['a', 'b', 'c']
                     }
                     json.dump(output, m2)
-            context = Context(self.delete, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'clear': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.delete)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['--name', params['name']])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f"Deleting repository {context.params['name']} from .meta file\n"
-                f"Repository {context.params['name']} successfully deleted\n"
+                f"Deleting repository {params['name']} from .meta file\n"
+                f"Repository {params['name']} successfully deleted\n"
             )
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc', 'test']))
@@ -639,26 +674,25 @@ class TestDelete(TestCase):
                     }
                 )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_delete_repository_does_not_exist(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_delete_repository_does_not_exist(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta'), join(f, '.meta'))
-            context = Context(self.delete, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'clear': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.delete)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.delete, ['--name', params['name'], '-c'])
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f"Deleting repository {context.params['name']} from .meta file\n"
-                f"Repository {context.params['name']} does not exist in the .meta file, ignoring\n"
+                f"Deleting repository {params['name']} from .meta file\n"
+                f"Repository {params['name']} does not exist in the .meta file, ignoring\n"
             )
             with open(join(f, '.meta'), 'r') as m:
                 self.assertEqual(
@@ -680,8 +714,8 @@ class TestLs(TestCase):
         self.runner = CliRunner()
         self.ls = ls
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_ls_repositories_available(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_ls_repositories_available(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -699,10 +733,10 @@ class TestLs(TestCase):
                         'tags': ['c', 'd', 'e']
                     }
                     json.dump(output, m2)
-            context = Context(self.ls, obj=GametaContext())
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.ls)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
@@ -713,8 +747,8 @@ class TestLs(TestCase):
                 "genisys\n"
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_ls_no_repositories_available(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_ls_no_repositories_available(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -724,10 +758,10 @@ class TestLs(TestCase):
                         'projects': {}
                     }, m
                 )
-            context = Context(self.ls, obj=GametaContext())
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.ls)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
@@ -741,72 +775,72 @@ class TestUpdate(TestCase):
         self.runner = CliRunner()
         self.update = update
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_no_name_specified(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_key_parameters_not_provided(self, mock_ensure_object):
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'new_name': None,
-                'new_url': None,
-                'new_path': None
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
             result = self.runner.invoke(self.update)
-            self.assertEqual(result.exit_code, 1)
+            self.assertEqual(result.exit_code, 2)
+            self.assertEqual(
+                result.output,
+                "Usage: update [OPTIONS]\n"
+                "Try 'update --help' for help.\n"
+                "\n"
+                "Error: Missing option '--name' / '-n'.\n"
+            )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_name_does_not_exist_in_repo(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_name_does_not_exist_in_repo(self, mock_ensure_object):
+        params = {
+            'name': 'test'
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'test',
-                'new_name': None,
-                'new_url': None,
-                'new_path': None,
-                'sync': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(self.update, ['--name', params['name']])
             self.assertEqual(result.exit_code, 1)
             self.assertEqual(
                 result.output,
-                f'Error: Repository {context.params["name"]} does not exist in the .meta file, please add it first\n'
+                f'Error: Repository {params["name"]} does not exist in the .meta file, please add it first\n'
             )
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_all_parameters_updated_gitignore_created(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_all_parameters_updated_gitignore_created(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_url': 'https://github.com/jantman/GitPython.git',
+            'new_path': 'core/GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_url': 'https://github.com/jantman/GitPython.git',
-                'new_path': 'core/GitPython',
-                'sync': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                ['--name', params['name'], '-e', params['new_name'], '-u', params['new_url'], '-p', params['new_path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -835,31 +869,33 @@ class TestUpdate(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertTrue("core/GitPython/\n" in g.readlines())
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_all_parameters_updated_gitignore_exists_but_does_not_contain_path(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_all_parameters_updated_gitignore_exists_but_does_not_contain_path(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_url': 'https://github.com/jantman/GitPython.git',
+            'new_path': 'core/GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
             copyfile(join(dirname(__file__), 'data', '.gitignore'), join(f, '.gitignore'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_url': 'https://github.com/jantman/GitPython.git',
-                'new_path': 'core/GitPython',
-                'sync': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                ['--name', params['name'], '-e', params['new_name'], '-u', params['new_url'], '-p', params['new_path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -888,8 +924,15 @@ class TestUpdate(TestCase):
             with open(join(f, '.gitignore'), 'r') as g:
                 self.assertTrue("core/GitPython/\n" in g.readlines())
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_all_parameters_updated_gitignore_exists_and_contains_path(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_all_parameters_updated_gitignore_exists_and_contains_path(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_url': 'https://github.com/jantman/GitPython.git',
+            'new_path': 'core/GitPython',
+            'sync': False
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
@@ -900,24 +943,20 @@ class TestUpdate(TestCase):
                     output.append('GitPython/\n')
                     output.append('core/gitdb/\n')
                     g2.writelines(output)
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_url': 'https://github.com/jantman/GitPython.git',
-                'new_path': 'core/GitPython',
-                'sync': False
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                ['--name', params['name'], '-e', params['new_name'], '-u', params['new_url'], '-p', params['new_path']]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -948,35 +987,43 @@ class TestUpdate(TestCase):
                 self.assertTrue("core/gitdb/\n" in output)
                 self.assertTrue("core/GitPython/\n" in output)
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_all_parameters_updated_with_physical_sync(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_all_parameters_updated_with_physical_sync(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_url': 'https://github.com/jantman/GitPython.git',
+            'new_path': 'core/GitPython',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_url': 'https://github.com/jantman/GitPython.git',
-                'new_path': 'core/GitPython',
-                'sync': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                [
+                    '--name', params['name'],
+                    '-e', params['new_name'],
+                    '-u', params['new_url'],
+                    '-p', params['new_path'],
+                    '-s'
+                ]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
                 "Performing a physical sync\n"
-                f"Cloning repository from new URL: {context.params['new_url']}\n"
+                f"Cloning repository from new URL: {params['new_url']}\n"
                 "Sync complete\n"
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -1005,35 +1052,42 @@ class TestUpdate(TestCase):
             self.assertTrue(exists(join(f, 'core', 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'core', 'GitPython')) for i in ['git', 'doc']))
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_no_new_path_updated_with_physical_sync(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_no_new_path_updated_with_physical_sync(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_path': None,
+            'new_url': 'https://github.com/jantman/GitPython.git',
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_path': None,
-                'new_url': 'https://github.com/jantman/GitPython.git',
-                'sync': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                [
+                    '--name', params['name'],
+                    '-e', params['new_name'],
+                    '-u', params['new_url'],
+                    '-s'
+                ]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
                 "Performing a physical sync\n"
-                f"Cloning repository from new URL: {context.params['new_url']}\n"
+                f"Cloning repository from new URL: {params['new_url']}\n"
                 "Sync complete\n"
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -1061,35 +1115,42 @@ class TestUpdate(TestCase):
             self.assertTrue(exists(join(f, 'GitPython')))
             self.assertTrue(all(i in listdir(join(f, 'GitPython')) for i in ['git', 'doc']))
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_no_new_url_updated_with_physical_sync(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_no_new_url_updated_with_physical_sync(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_path': 'core/gitpython',
+            'new_url': None,
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_path': 'core/gitpython',
-                'new_url': None,
-                'sync': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                [
+                    '--name', params['name'],
+                    '-e', params['new_name'],
+                    '-p', params['new_path'],
+                    '-s'
+                ]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
                 "Performing a physical sync\n"
-                f"Copying repository to new path: {context.params['new_path']}\n"
+                f"Copying repository to new path: {params['new_path']}\n"
                 "Sync complete\n"
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(
@@ -1118,35 +1179,41 @@ class TestUpdate(TestCase):
             self.assertTrue(exists(join(f, 'core', 'gitpython')))
             self.assertTrue(all(i in listdir(join(f, 'core', 'gitpython')) for i in ['git', 'doc', 'test']))
 
-    @patch('gameta.click.BaseCommand.make_context')
-    def test_update_only_name_change_updated_with_physical_sync(self, mock_context):
+    @patch('gameta.click.Context.ensure_object')
+    def test_update_only_name_change_updated_with_physical_sync(self, mock_ensure_object):
+        params = {
+            'name': 'GitPython',
+            'new_name': 'test',
+            'new_path': None,
+            'new_url': None,
+        }
         with self.runner.isolated_filesystem() as f:
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'git.zip'), 'r') as template:
                 template.extractall(f)
             with zipfile.ZipFile(join(dirname(__file__), 'data', 'gitpython.zip'), 'r') as template:
                 template.extractall(f)
             copyfile(join(dirname(__file__), 'data', '.meta_other_repos'), join(f, '.meta'))
-            context = Context(self.update, obj=GametaContext())
-            context.params = {
-                'name': 'GitPython',
-                'new_name': 'test',
-                'new_path': None,
-                'new_url': None,
-                'sync': True
-            }
-            context.obj.project_dir = f
-            context.obj.load()
-            mock_context.return_value = context
-            result = self.runner.invoke(self.update)
+            context = GametaContext()
+            context.project_dir = f
+            context.load()
+            mock_ensure_object.return_value = context
+            result = self.runner.invoke(
+                self.update,
+                [
+                    '--name', params['name'],
+                    '-e', params['new_name'],
+                    '-s'
+                ]
+            )
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output,
-                f'Updating repository GitPython with new details (name: {context.params["new_name"]}, '
-                f'url: {context.params["new_url"]}, path: {context.params["new_path"]})\n'
+                f'Updating repository GitPython with new details (name: {params["new_name"]}, '
+                f'url: {params["new_url"]}, path: {params["new_path"]})\n'
                 "Performing a physical sync\n"
                 "No physical changes\n"
                 "Sync complete\n"
-                f'Successfully updated repository {context.params["new_name"]} with new details\n'
+                f'Successfully updated repository {params["new_name"]} with new details\n'
             )
             with open(join(f, '.meta')) as m:
                 self.assertEqual(


### PR DESCRIPTION
Adding new parameters CLI that enables users to:

1. Add parameters that can be used to render and execute commands
2. Delete parameters, except reserved parameter values